### PR TITLE
Fix extraneous 0 values in coordinates

### DIFF
--- a/SpatialHelper.php
+++ b/SpatialHelper.php
@@ -48,7 +48,7 @@ abstract class SpatialHelper { // declare abstract, we don't want instances (tri
     }
 
     protected static function explodePoint($pnt)    {
-        return array_map('floatval', explode(' ', $pnt));
+        return array_map('floatval', explode(' ', trim($pnt)));
     }
 
     protected static function explodePoints($pntsWkt)    {


### PR DESCRIPTION
This PR fixes a bug caused by unaccounted for spaces in WKT coordinate strings. Note the following WKT: 
```
POLYGON((1 1, 5 1, 5 5, 1 5, 1 1))
```
The spaces after the commas will result in a zero (0) in the first value of the coordinate arrays after the first conversion when calling `SpatialHelper::wktToGeom()`:

```
array (
  'type' => 'Polygon',
  'coordinates' => 
  array (
    0 => 
    array (
      0 => 
      array (
        0 => 1,
        1 => 1,
      ),
      1 => 
      array (
        0 => 0,
        1 => 5,
        2 => 1,
      ),
      2 => 
      array (
        0 => 0,
        1 => 5,
        2 => 5,
      ),
      3 => 
      array (
        0 => 0,
        1 => 5,
        2 => 5,
      ),
      4 => 
      array (
        0 => 0,
        1 => 1,
        2 => 1,
      ),
    ),
  ),
)
```

The zero (0) is produced by a call to `explode()` before trimming preceding and trailing whitespace from the string being exploded.  